### PR TITLE
Hp auto scroll messages

### DIFF
--- a/src/components/articles/Article.css
+++ b/src/components/articles/Article.css
@@ -79,7 +79,7 @@ color: whitesmoke;
 }
 
 .newMessage {
-    width: 900px;
+    width: 50em;
     height: 50px;
 }
 .message-btns {

--- a/src/components/messages/PublicMessageList.js
+++ b/src/components/messages/PublicMessageList.js
@@ -1,10 +1,11 @@
 // Ethan Mathis -- purpose is to render all public messages in one board and allow users to post new messages
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { getAllMessages, deleteMessage, updateMessage, getMessageById } from "../../modules/MessageManager"
 import { MessageCard } from './MessageCard'
 import { NewMessageInput } from './NewMessage'
 import { getUserFriends, addFriend} from '../../modules/friendsListManager'
+
 
 
 export const MessageList = () => {
@@ -63,6 +64,16 @@ export const MessageList = () => {
         .then(() => getMessages())
     }
 
+
+    const messagesEndRef = useRef(null)
+    const scrollToBottom = () => {
+        messagesEndRef.current.scrollIntoView({behavior: "smooth"})
+    }
+    useEffect(() => {
+        scrollToBottom()
+        console.log("messages")
+    }, [messages])
+
     useEffect(() => {
         getMessageFriends()
     }, [messages])
@@ -84,7 +95,7 @@ export const MessageList = () => {
                handleDelete={handleDelete}
                
                 /> )}
-
+            <div ref={messagesEndRef} />
             </div> 
             <div className="messageInput">
                 <NewMessageInput getMessages={getMessages} />

--- a/src/components/messages/PublicMessageList.js
+++ b/src/components/messages/PublicMessageList.js
@@ -116,10 +116,10 @@ export const MessageList = () => {
                
                 /> )}
             <div ref={messagesEndRef} />
-            </div> 
+            </div>                  
             <div className="messageInput">
                 <NewMessageInput getMessages={getMessages} />
-            </div>                  
+            </div> 
         </section>
     )
 }

--- a/src/components/messages/PublicMessageList.js
+++ b/src/components/messages/PublicMessageList.js
@@ -91,7 +91,7 @@ export const MessageList = () => {
     }
     useEffect(() => {
         scrollToBottom()
-        console.log("messages")
+        
     }, [messages])
 
     useEffect(() => {


### PR DESCRIPTION
# Description
Implemented logic to auto scroll message list to the bottom when a new message is added.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions
Go to messages and type a new message, hit send and the page should auto scroll if needed to show the newest message.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works